### PR TITLE
Pi live E2E runs as an associated, manually-approved PR check

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -49,6 +49,7 @@ on:
   # Same-repo PRs get the secret; the live job stays per-variant environment-gated.
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
@@ -85,7 +86,7 @@ jobs:
   # Pull requests normalize to one Sonnet 5 leg. Manual dispatches choose the
   # routine Sonnet cadence or the separately approved Opus pre-release cadence.
   claude-live:
-    if: ${{ github.event_name == 'pull_request' || inputs.live_cadence == 'sonnet' || inputs.live_cadence == 'opus-pre-release' }}
+    if: ${{ (github.event_name == 'pull_request' || inputs.live_cadence == 'sonnet' || inputs.live_cadence == 'opus-pre-release') && github.event.action != 'labeled' }}
     needs: offline
     # The offline gate runs first without secrets. The selected live leg then
     # waits for its CI-E2E or CI-E2E-OPUS approval.
@@ -314,7 +315,7 @@ jobs:
           if-no-files-found: warn
 
   codex-live:
-    if: ${{ github.event_name == 'pull_request' || inputs.live_cadence == 'sonnet' }}
+    if: ${{ (github.event_name == 'pull_request' || inputs.live_cadence == 'sonnet') && github.event.action != 'labeled' }}
     needs: offline
     runs-on: ubuntu-latest
     environment:
@@ -580,7 +581,7 @@ jobs:
           if-no-files-found: warn
 
   pi-live:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.live_cadence == 'pi' }}
+    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'live:pi')) || (github.event_name == 'workflow_dispatch' && inputs.live_cadence == 'pi') }}
     needs: offline
     runs-on: ubuntu-latest
     environment:
@@ -839,7 +840,7 @@ jobs:
   # are restated here for checkout and cross-job artifact download.
   journey-delta-comment:
     needs: [claude-live, codex-live]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action != 'labeled'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -168,7 +168,7 @@ Workflow: `.github/workflows/runtime-live-e2e.yml`. The offline gate job (`go te
 
 - Pull requests run `claude-sonnet-5` at maximum effort and `gpt-5.6-luna` at maximum effort.
 - An explicit `live_cadence=opus-pre-release` dispatch runs offline plus `claude-opus-4-8` at maximum effort. It allocates no Codex or Pi runner and requests only `CI-E2E-OPUS` approval.
-- An explicit `live_cadence=pi` dispatch runs the 17 common Pi journeys and the Pi front-door proof with `openai-codex/gpt-5.6-luna` for OAuth or `openai/gpt-5.6-luna` for the API-key fallback, at maximum thinking. It waits only for `CI-E2E-PI` approval and retains Pi logs, diagnostics, journey metrics, and session artifacts. Pull requests still run only Sonnet and Codex; Pi is optional and is not a merge requirement. Local Pi execution remains supported with `pi login` or an API key.
+- An explicit `live_cadence=pi` dispatch runs the 17 common Pi journeys and the Pi front-door proof with `openai-codex/gpt-5.6-luna` for OAuth or `openai/gpt-5.6-luna` for the API-key fallback, at maximum thinking. It waits only for `CI-E2E-PI` approval and retains Pi logs, diagnostics, journey metrics, and session artifacts. Pull requests run Sonnet and Codex; Pi is opt-in per PR — add the `live:pi` label and approve the `CI-E2E-PI` environment to attach a Pi live check to the PR. Pi is not a merge requirement. Local Pi execution remains supported with `pi login` or an API key.
 
 All live lanes must test the current checkout, not a remote `--ref next` install. The Codex lane generates a local marketplace under `$RUNNER_TEMP`:
 


### PR DESCRIPTION
Pi live E2E is currently the only live lane that never runs on a pull request, and a manual `workflow_dispatch` run produces no check on the PR — so pi live evidence is neither PR-associated nor per-PR triggerable. This change makes pi live an opt-in, PR-associated check using the same pattern the claude/codex lanes already prove in production.

## What changed

- Widen the `pull_request` trigger of `runtime-live-e2e.yml` with `labeled` (plus `synchronize`, already implied by the existing list): `types: [opened, synchronize, reopened, labeled]`.
- Label-gate `pi-live` onto PR events: `pi-live` runs when the PR carries `live:pi` (checked via `contains(github.event.pull_request.labels.*.name, 'live:pi')`); the manual `workflow_dispatch` cadence leg is byte-identical to before.
- Spillover guard: `claude-live`, `codex-live`, and `journey-delta-comment` each gain `&& github.event.action != 'labeled'` (parenthesized where their condition is a disjunction) so adding *any* label re-runs no paid lane; the secret-free `offline` gate stays unconditional.
- `docs/runtime-live-ci.md` documents the new opt-in: "Pull requests run Sonnet and Codex; Pi is opt-in per PR — add the `live:pi` label and approve the `CI-E2E-PI` environment".

The existing `CI-E2E-PI` environment (required reviewer + `CODEX_AUTH_JSON`) is unchanged — the label opts in, the environment approval is the human gate, and the run appears in the PR's Checks tab.

## Evidence

- actionlint v1.7.12 over the edited workflow: 0 errors (re-run fresh at validation; implementation ran 1.7.7, also clean).
- Byte-exact verification of all four edited conditions against both the pre-image and the ideation-approved wording; adversarial audit of every `pull_request`-keyed expression: manual dispatch unaffected (`workflow_dispatch` has no `action`), unlabeled PRs trigger no live job, non-pi label events run only the secret-free `offline` gate.
- `CI-E2E-PI` re-verified live: environment exists with `required_reviewers` (clkao) and the `CODEX_AUTH_JSON` secret.
- Surface: +6/−5 across 2 files vs declared ≈+9/−4 + doc line — within tolerance; no tests added per captain directive (diff touches no Go code).
- Live dogfood (AC-1/AC-2/AC-4) is deferred by design to this PR's own checks: before labeling, no pi-live run appears; after adding `live:pi` and approving the environment, the PR-associated pi-live run appears — that observation is the delivery-gate condition recorded at the validation gate.

---
[6v7](/spacedock-dev/spacedock/blob/60dd21dff2f71aab64d6efe96c58ef972076b548/pi-live-pr-check-lane.md)
