### PR TITLE
Single-owner FO contract bootstrap on Pi: extension-owned injection, version self-check, resolvable skill trigger

### DIFF
--- a/.pi/extensions/spacedock.test.ts
+++ b/.pi/extensions/spacedock.test.ts
@@ -1,0 +1,125 @@
+// Unit tests for the Spacedock pi extension module (.pi/extensions/spacedock.ts):
+// the PI_SPACEDOCK_LAUNCH injection gate (AC-1/AC-4) and the resources_discover
+// manifest-skip (the intra-package double-registration remedy). Run: bun test
+// ./.pi/extensions/spacedock.test.ts
+import { describe, expect, test } from "bun:test";
+import registerSpacedockExtension from "./spacedock.ts";
+
+type Handler = (event?: any) => any;
+
+function makeFakePi() {
+	const handlers: Record<string, Handler> = {};
+	return {
+		handlers,
+		on(name: string, handler: Handler) {
+			handlers[name] = handler;
+		},
+		exec: async () => ({ code: 0, stdout: "" }),
+	};
+}
+
+function userMessage(text: string) {
+	return { role: "user", content: [{ type: "text", text }] };
+}
+
+function injectedText(result: any): string {
+	const messages = result?.messages ?? [];
+	return messages
+		.map((message: any) =>
+			(message?.content ?? [])
+				.filter((part: any) => part?.type === "text")
+				.map((part: any) => part?.text ?? "")
+				.join(""),
+		)
+		.join("\n");
+}
+
+async function runContext(handler: Handler | undefined, messages: any[]) {
+	if (!handler) throw new Error("no context handler registered");
+	return await handler({ messages });
+}
+
+function withEnv(key: string, value: string | undefined, run: () => void | Promise<void>) {
+	const prior = process.env[key];
+	const restore = () => {
+		if (prior === undefined) delete process.env[key];
+		else process.env[key] = prior;
+	};
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+	return Promise.resolve()
+		.then(run)
+		.finally(restore);
+}
+
+// The test runner itself may run inside a pi-subagents child (PI_SUBAGENT_CHILD=1);
+// the injection gate reads it at handler time, so pin it out of the way.
+function asParentSession(run: () => void | Promise<void>) {
+	return withEnv("PI_SUBAGENT_CHILD", undefined, run);
+}
+
+describe("spacedock extension FO injection gate", () => {
+	test("plain session (no PI_SPACEDOCK_LAUNCH) receives NO bootstrap", async () => {
+		const fake = makeFakePi();
+		registerSpacedockExtension(fake as any);
+		await asParentSession(() =>
+			withEnv("PI_SPACEDOCK_LAUNCH", undefined, async () => {
+				fake.handlers["session_start"]?.();
+				const result = await runContext(fake.handlers["context"], [userMessage("operator task")]);
+				expect(result).toBeUndefined();
+			}),
+		);
+	});
+
+	test("frontdoor launch (PI_SPACEDOCK_LAUNCH=1) injects the bootstrap with the resolvable wording", async () => {
+		const fake = makeFakePi();
+		registerSpacedockExtension(fake as any);
+		await asParentSession(() =>
+			withEnv("PI_SPACEDOCK_LAUNCH", "1", async () => {
+				fake.handlers["session_start"]?.();
+				const result = await runContext(fake.handlers["context"], [userMessage("operator task")]);
+				const text = injectedText(result);
+				expect(text).toContain("SPACEDOCK-FO-BOOTSTRAP-v1");
+				// Resolvable trigger: the <available_skills> listing, not unexpandable
+				// $spacedock: syntax and not a relative SKILL.md path.
+				expect(text).toContain("<available_skills>");
+				expect(text).not.toContain("$spacedock:");
+				expect(text).not.toContain("skills/first-officer/SKILL.md");
+			}),
+		);
+	});
+
+	test("compaction boot-record injection carries the same gate", async () => {
+		const fake = makeFakePi();
+		registerSpacedockExtension(fake as any);
+		await asParentSession(() =>
+			withEnv("PI_SPACEDOCK_LAUNCH", undefined, async () => {
+				fake.handlers["session_start"]?.();
+				fake.handlers["session_compact"]?.();
+				const result = await runContext(fake.handlers["context"], [userMessage("compaction summary")]);
+				expect(result).toBeUndefined();
+			}),
+		);
+		await asParentSession(() =>
+			withEnv("PI_SPACEDOCK_LAUNCH", "1", async () => {
+				fake.handlers["session_start"]?.();
+				fake.handlers["session_compact"]?.();
+				const result = await runContext(fake.handlers["context"], [userMessage("compaction summary")]);
+				expect(injectedText(result)).toContain("SPACEDOCK-FO-BOOT-v2");
+			}),
+		);
+	});
+});
+
+describe("spacedock extension resources_discover manifest-skip", () => {
+	test("skips the skills dir the package manifest already declares", () => {
+		const fake = makeFakePi();
+		registerSpacedockExtension(fake as any);
+		// This test lives in <repoRoot>/.pi/extensions/, so the module's
+		// repoRoot resolves to the Spacedock checkout whose package.json
+		// declares pi.skills: ["./skills"] — the manifest route. The
+		// extension must NOT re-register that directory.
+		const result = fake.handlers["resources_discover"]?.();
+		expect(result).toEqual({ skillPaths: [] });
+	});
+});

--- a/.pi/extensions/spacedock.ts
+++ b/.pi/extensions/spacedock.ts
@@ -11,10 +11,13 @@
 // from the package's own `skills/` directory — resolved relative to this
 // extension's location, exactly like the obra/superpowers reference.
 //
-// It also commissions the parent session as Spacedock first officer through
-// Pi's context hook. The launcher keeps only its minimal skill-trigger prompt;
-// this extension owns the durable warm/contract bootstrap because context hooks
-// can re-inject after compaction while launch argv prompts cannot.
+// It also installs the FO contract in the parent session through
+// Pi's context hook. The launcher keeps only its argv-only duties (pass the
+// operator task, suppress the launch prompt on resume); this extension owns
+// the durable contract bootstrap because context hooks can re-inject after
+// compaction while launch argv prompts cannot, and the injection is gated on
+// the PI_SPACEDOCK_LAUNCH=1 marker `spacedock pi` sets on every launch — a
+// plain `pi` session for unrelated work receives no bootstrap.
 //
 // Compaction boundary: PR #738 (force-boot-at-compaction-boundary) established
 // that at compaction the FO re-reads durable state (one «state.boot»()), NOT
@@ -25,10 +28,18 @@
 // #738 rejected.
 
 import { fileURLToPath } from "node:url";
+import * as fs from "node:fs";
 import * as path from "node:path";
 
 const FO_BOOTSTRAP_MARKER = "SPACEDOCK-FO-BOOTSTRAP-v1";
-const FO_BOOTSTRAP_TEXT = `<EXTREMELY_IMPORTANT>\n[${FO_BOOTSTRAP_MARKER}] You are the Spacedock first officer. Load the $spacedock:first-officer skill (skills/first-officer/SKILL.md) and treat it as your operating contract: re-satisfy every load precondition at its trigger (shared core, runtime adapter, write/merge/dispatch cores), re-read durable state before the next workflow effect — the compacted summary is not authoritative. Pi tool mapping: read/write/edit/bash/grep/find/ls; load skills via read; subagent via pi-subagents when available; plans live in plan files / TODO.md.\n</EXTREMELY_IMPORTANT>`;
+// The bootstrap names the RESOLVABLE trigger: the first-officer entry of the
+// session's <available_skills> listing, whose location pi resolves from the
+// registered package root regardless of cwd. No `$spacedock:` syntax (pi
+// expands /skill: on user input only — a launch-injected message is not user
+// input) and no relative SKILL.md path (ENOENT from any workflow cwd — the
+// 2026-09-10 stale-skill incident's failure shape). /skill:first-officer
+// remains the human-invocable form in interactive input.
+const FO_BOOTSTRAP_TEXT = `<EXTREMELY_IMPORTANT>\n[${FO_BOOTSTRAP_MARKER}] You are the Spacedock first officer. Load the first-officer skill's SKILL.md at the exact location listed for it in your available skills (<available_skills>) and treat it as your operating contract: re-satisfy every load precondition at its trigger (shared core, runtime adapter, write/merge/dispatch cores), re-read durable state before the next workflow effect — the compacted summary is not authoritative. Pi tool mapping: read/write/edit/bash/grep/find/ls; load skills via read; subagent via pi-subagents when available; plans live in plan files / TODO.md.\n</EXTREMELY_IMPORTANT>`;
 
 const FO_BOOT_RECORD_MARKER = "[SPACEDOCK-FO-BOOT-v2]";
 const FO_BOOT_RECORD_DIRECTIVE = `${FO_BOOT_RECORD_MARKER} Durable state boot record — re-read before the next workflow effect. The compacted summary is not authoritative. Resume the loop where it stopped; do NOT greet or re-present a session summary. Pi tool mapping: read/write/edit/bash/grep/find/ls; load skills via read; subagent via pi-subagents when available.`;
@@ -37,7 +48,32 @@ const FO_BOOT_RECORD_DIRECTIVE = `${FO_BOOT_RECORD_MARKER} Durable state boot re
 // (src/runs/shared/pi-args.ts); a child is a delegated worker by definition,
 // so commissioning one as first officer would leak the FO contract into
 // ensign boots. Skill discovery still applies; only FO injection is exempt.
-const isPiSubagentChild = process.env.PI_SUBAGENT_CHILD === "1";
+// Both gates are read at handler time so a probe/test can flip them.
+function isPiSubagentChild() {
+	return process.env.PI_SUBAGENT_CHILD === "1";
+}
+
+// isFrontdoorLaunch: the PI_SPACEDOCK_LAUNCH=1 marker `spacedock pi` sets on
+// EVERY launch shape (wrap and non-wrap, installed and dev override). Without
+// it — a plain `pi` session for unrelated work, a user's own project session —
+// the FO bootstrap is NOT injected. This is the single-owner gate: the
+// extension, not the launch prompt, delivers the contract.
+function isFrontdoorLaunch() {
+	return process.env.PI_SPACEDOCK_LAUNCH === "1";
+}
+
+// manifestDeclaredSkillDirs resolves the package manifest's `pi.skills` entries
+// against repoRoot. Each declared dir is a skill-registration route pi already
+// scans — resources_discover returning the same dir again doubles every skill
+// registration (the packages x routes duplicate condition).
+function manifestDeclaredSkillDirs(repoRoot) {
+	try {
+		const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+		return (manifest?.pi?.skills ?? []).map((entry) => path.resolve(repoRoot, entry));
+	} catch {
+		return [];
+	}
+}
 
 function messageText(message) {
 	if (Array.isArray(message?.content)) {
@@ -74,6 +110,14 @@ export default function registerSpacedockExtension(pi) {
 		// .pi/extensions/ -> ../.. -> repo root -> skills/
 		const repoRoot = path.resolve(extDir, "..", "..");
 		const skillsDir = path.join(repoRoot, "skills");
+		if (manifestDeclaredSkillDirs(repoRoot).includes(skillsDir)) {
+			// The package manifest's pi.skills scan already registers this
+			// directory; re-registering it here doubles every skill
+			// registration. Skip it — the manifest route is the one that
+			// counts, and the doctor's route-aware duplicate count shrinks
+			// accordingly.
+			return { skillPaths: [] };
+		}
 		return { skillPaths: [skillsDir] };
 	});
 
@@ -92,7 +136,7 @@ export default function registerSpacedockExtension(pi) {
 	});
 
 	pi.on("context", async (event) => {
-		if (isPiSubagentChild) return;
+		if (isPiSubagentChild() || !isFrontdoorLaunch()) return;
 
 		if (injectBootRecord) {
 			if (event.messages.some(hasBootRecord)) return;

--- a/docs/site/contributing/adding-a-runtime.md
+++ b/docs/site/contributing/adding-a-runtime.md
@@ -169,13 +169,26 @@ Required worker actions:
 After subagent(...) returns, you as first officer must verify the entity file contains PI-LIVE-SUBAGENT-ENSIGN-SMOKE and verify the state checkout git log contains 'ensign: pi live smoke'. Exit successfully only after those durable checks pass.
 ```
 
+### First-officer contract bootstrap (Pi)
+
+The FO contract has one owner on Pi: the Spacedock extension. The frontdoor launch prompt carries no contract sentence — it passes the operator task and suppresses the launch prompt on resume; the extension injects the contract through Pi's context hook, gated on the `PI_SPACEDOCK_LAUNCH=1` marker `spacedock pi` sets on every launch, so a plain `pi` session for unrelated work receives no bootstrap. The bootstrap names the resolvable trigger: the `first-officer` entry of the session's `<available_skills>` listing, whose location pi resolves from the registered package root regardless of cwd (`/skill:first-officer` remains the human-invocable form in interactive input; the model loads the skill by reading the listed location).
+
+Three facts about this surface that session evidence cannot show directly:
+
+- **Compaction contract.** At a compaction boundary the FO re-reads durable state via the boot-record injection (PR #738); the contract is never re-injected.
+- **Request-time only.** Context-hook injections are never persisted to session logs. Absence of the bootstrap message in a session log is NOT evidence that it was absent at request time.
+- **Duplicate registration.** When two registered packages both provide `first-officer` (e.g. a dev-link checkout and the installed git package), pi's skill scan is first-match: the first `settings.json` entry wins. Each package also registers its skills through two routes (the manifest's `pi.skills` scan and the extension's `resources_discover`, which skips paths the manifest already declares). `spacedock doctor --host pi` and launch output flag the condition with a route-aware count; the remedy is `pi remove` of the stale entry.
+- **Dev-override double extension.** Under the dev override (`SPACEDOCK_REPO_ROOT` / `--plugin-dir` install source), the checkout's `spacedock.ts` loads via `--extension` while the installed package's `spacedock.ts` loads via package discovery; `spacedock doctor --host pi` and launch output flag the double load.
+- **Version floor.** The mechanism requires `pi >= 0.83` (context-hook injection; `<available_skills>` with absolute per-skill locations; `/skill:` user-input-only expansion). The ready gate and doctor read the binary's `pi --version`; a sub-floor install is refused at launch and flagged by `doctor` (pi now publishes as `@earendil-works`; the old `@mariozechner` line is stale).
+
 ### Skill install and load paths
 
-For Pi, `spacedock pi` launches the proven front door by loading local resources explicitly:
+For Pi, `spacedock pi` launches the front door through the registered Spacedock package: the package's `.pi/extensions/spacedock.ts` discovers the Spacedock skills (`first-officer`, `ensign`, …) from the package's own `skills/` directory via pi's `resources_discover`, and installs the FO contract through Pi's context hook, gated on the `PI_SPACEDOCK_LAUNCH=1` marker the frontdoor sets on every launch:
 
 ```text
-<spacedock checkout>/skills/first-officer
-<spacedock checkout>/skills/ensign
+<spacedock package root>/.pi/extensions/spacedock.ts   (registered package or --plugin-dir dev override)
+<spacedock package root>/skills/first-officer
+<spacedock package root>/skills/ensign
 ~/.pi/agent/npm/node_modules/pi-subagents/skills/pi-subagents
 ~/.pi/agent/npm/node_modules/pi-subagents/src/extension/index.ts
 ```

--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -17,7 +18,24 @@ import (
 	"github.com/spacedock-dev/spacedock/internal/safehouse"
 )
 
-const piBootstrapPrompt = "Use $spacedock:first-officer for this whole Pi session."
+// piLaunchMarkerEnv is the frontdoor launch marker: runPi sets it to 1 in the
+// launched child env on every launch shape and the extension gates its
+// FO-bootstrap injection on it. Deliberately NOT SPACEDOCK_BIN (fo-install.md
+// tells users to set that session-scoped). The wrap forwards it via --env-pass.
+const piLaunchMarkerEnv = "PI_SPACEDOCK_LAUNCH"
+
+// piVersionFloor is the declared floor for the load-bearing pi behaviors the
+// FO bootstrap mechanism rests on (context-hook injection; <available_skills>
+// with absolute per-skill locations; /skill: user-input-only expansion).
+// Enforced from the binary's `pi --version` only — never package paths.
+const piVersionFloor = "0.83.0"
+
+// piSkillRoutesPerPackage is the number of skill-registration routes each
+// registered package contributes: the manifest's `pi.skills` scan AND the
+// extension's resources_discover (which historically re-registered the same
+// skills/ directory its own manifest already declares). The duplicate
+// count is route-aware: packages x routes.
+const piSkillRoutesPerPackage = 2
 
 // piSpacedockPackageSource is the published install source for the Spacedock
 // package. `spacedock install --host pi` runs `pi install <source>`, which
@@ -41,6 +59,9 @@ type piRuntimeOps interface {
 	// agentDir is the pi agent directory (~/.pi/agent or PI_CODING_AGENT_DIR);
 	// home is used to resolve ~ entries.
 	SpacedockPackageStatus(agentDir, home string) piPackageStatus
+	// PiVersion runs the pi binary's `pi --version` — the binary-level read
+	// the 0.83.0 floor is enforced from (no package paths); tests fake it.
+	PiVersion() (string, error)
 }
 
 // piPackageStatus is the result of the package-registration + skill-discovery
@@ -50,8 +71,13 @@ type piPackageStatus struct {
 	ensignDiscoverable       bool
 	firstOfficerDiscoverable bool
 	source                   string // the settings.json packages entry for spacedock
-	packageRoot              string // the resolved package root
+	packageRoot              string // the resolved package root (first match wins)
 	subagentsRegistered      bool   // a package named pi-subagents is in settings.json packages
+	// spacedockEntries counts spacedock entries in settings.json (>1 is the
+	// duplicate-registration condition); packageRoots lists every spacedock
+	// root in settings order — the first is the winner (first-match scan).
+	spacedockEntries int
+	packageRoots     []string
 }
 
 type execPiRuntimeOps struct{}
@@ -161,6 +187,11 @@ func (execPiRuntimeOps) SpacedockPackageStatus(agentDir, home string) piPackageS
 	return piSpacedockPackageStatus(agentDir, home)
 }
 
+func (execPiRuntimeOps) PiVersion() (string, error) {
+	out, err := exec.Command("pi", "--version").Output()
+	return string(out), err
+}
+
 type piRuntimeConfig struct {
 	repoRoot              string // dev-override only: --plugin-dir / SPACEDOCK_REPO_ROOT
 	packageRoot           string
@@ -189,12 +220,24 @@ type piCheckResult struct {
 	intercomPackageOK         bool
 	intercomSkillOK           bool
 	spacedockPackageOK        bool
-	packageStatus             piPackageStatus
-	packageRoot               string
-	intercomPackageRoot       string
-	repoRoot                  string
-	authPath                  string
-	sessionDir                string
+	// firstOfficerSkillOK / spacedockExtensionOK: the package's first-officer
+	// skill is discoverable (AC-5b) and its .pi/extensions/spacedock.ts exists
+	// (AC-5a — the FO contract delivery path).
+	firstOfficerSkillOK  bool
+	spacedockExtensionOK bool
+	// piVersionOK: `pi --version` parses at the 0.83.0 floor (binary-level).
+	piVersionOK bool
+	piVersion   string
+	// doubleExtensionLoad: repoRoot set (checkout spacedock.ts loads via
+	// --extension) AND a spacedock package registered (installed copy loads
+	// via package discovery).
+	doubleExtensionLoad bool
+	packageStatus       piPackageStatus
+	packageRoot         string
+	intercomPackageRoot string
+	repoRoot            string
+	authPath            string
+	sessionDir          string
 }
 
 func runPi(ctx context.Context, args []string, dir string, env []string, ops piRuntimeOps, stdout, stderr io.Writer) int {
@@ -210,6 +253,11 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 		fmt.Fprint(stderr, "spacedock pi: Pi runtime is not ready; run `spacedock doctor --host pi` or `spacedock install --host pi`\n")
 		printPiDoctorReport(stdout, check)
 		return 1
+	}
+	// Duplicate/double-extension warnings are loud but NON-fatal: resolution
+	// stays deterministic (first-match scan), so the launch proceeds.
+	for _, warning := range piLaunchWarnings(check) {
+		fmt.Fprintf(stderr, "spacedock pi: WARNING %s\n", warning)
 	}
 
 	// Translate the de-prefixed safehouse knobs into the safehouse `extra` slot
@@ -268,14 +316,12 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 		}
 	}
 	argv = append(argv, fd.passthrough...)
-	// Suppress the fresh-start bootstrap prompt on a resume, mirroring the
-	// Claude/Codex front door (frontdoor.go containsResume): a resume carries
-	// its own session intent and the FO contract survives in the system prompt
-	// via resources_discover, so re-injecting piBootstrapPrompt would tell the
-	// resumed session to load the contract as if starting fresh. Covers --resume,
-	// --resume=<id>, -r, --continue, -c (the same token set as containsResume).
-	if !containsResume(fd.passthrough) {
-		argv = append(argv, launchPrompt(piBootstrapPrompt, fd))
+	// The launch prompt is argv-only: pass the operator task, suppress on
+	// resume (containsResume). The contract is NOT carried here — pi expands
+	// /skill: on user input only, so no argv-embeddable syntax can deliver it;
+	// the extension's PI_SPACEDOCK_LAUNCH-gated injection owns that.
+	if !containsResume(fd.passthrough) && fd.hasTask {
+		argv = append(argv, fd.task)
 	}
 	// Resolve the fnm per-shell multishell symlink to its stable node-installation
 	// bin so execHost.Launch's stdlib exec.LookPath(<absolute>) hands Node a script
@@ -317,21 +363,21 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 			return 1
 		}
 		// Mirror claude/codex's wrap plumbing (frontdoor.go:345):
-		// launcherBinEnvPassFlags() forwards SPACEDOCK_BIN through the sandbox via
-		// --env-pass (launchEnv sets it on the safehouse process; the flag carries
-		// it through) so the launcher the helper calls resolve survives the
-		// boundary. The pi-specific load-bearing addition is
-		// --safehouse-add-dirs <fnmSandboxDir>: the dir whose node_modules holds
-		// the stable `pi`'s real script + hoisted deps (computed by
-		// fnmStableSandboxDir), which the sandbox cannot see by default. Targeted —
-		// grants pi's actual code+dep tree, not the whole filesystem.
+		// launcherBinEnvPassFlags() forwards SPACEDOCK_BIN via --env-pass. The
+		// pi-specific additions are --safehouse-add-dirs <fnmSandboxDir> (the
+		// stable `pi`'s code+deps, see fnmStableSandboxDir) and --env-pass
+		// PI_SPACEDOCK_LAUNCH so the gated injection fires under wrap too.
 		piExtra := append(launcherBinEnvPassFlags(), extra...)
+		piExtra = append(piExtra, "--env-pass", piLaunchMarkerEnv)
 		if fnmSandboxDir != "" {
 			piExtra = append(piExtra, "--add-dirs="+fnmSandboxDir)
 		}
 		argv = safehouse.Wrap(argv, piExtra)
 	}
-	code, err := ops.Launch(argv, launchEnv(os.Environ()))
+	// PI_SPACEDOCK_LAUNCH=1 on EVERY launch shape: the extension's injection
+	// gate. A plain `pi` session carries no marker and receives no bootstrap.
+	launchEnvList := append(launchEnv(os.Environ()), piLaunchMarkerEnv+"=1")
+	code, err := ops.Launch(argv, launchEnvList)
 	if err != nil {
 		fmt.Fprintf(stderr, "spacedock pi: launch failed: %v\n", err)
 		return 1
@@ -586,6 +632,10 @@ func checkPiRuntime(ops piRuntimeOps, cfg piRuntimeConfig) piCheckResult {
 	status := ops.SpacedockPackageStatus(cfg.agentDir, cfg.home)
 	res.packageStatus = status
 	res.spacedockPackageOK = status.registered && status.ensignDiscoverable
+	// Dev-override double-extension load: a static consequence of runPi's
+	// dev-override argv block (checkout via --extension, installed copy via
+	// package discovery). Flagged, not left to emergent behavior.
+	res.doubleExtensionLoad = cfg.repoRoot != "" && status.registered
 	// Dev override: --plugin-dir / SPACEDOCK_REPO_ROOT points at a local
 	// Spacedock checkout. When the package is not registered in settings.json
 	// (e.g. a fresh pi-home), the dev-override checkout satisfies the gate if
@@ -605,11 +655,83 @@ func checkPiRuntime(ops piRuntimeOps, cfg piRuntimeConfig) piCheckResult {
 			subagentsRegistered:      res.packageStatus.subagentsRegistered,
 		}
 	}
+	// The package's extension + first-officer skill are the FO contract's
+	// delivery path (AC-5): the ready gate refuses when either is missing.
+	if res.packageStatus.packageRoot != "" {
+		res.spacedockExtensionOK = ops.Stat(filepath.Join(res.packageStatus.packageRoot, ".pi", "extensions", "spacedock.ts")) == nil
+		res.firstOfficerSkillOK = res.packageStatus.firstOfficerDiscoverable
+	}
+	// pi version floor: read at the BINARY level only (`pi --version`; no
+	// package paths). A sub-floor binary fails the same not-ready path — it
+	// IS the stale old-org install signal.
+	if version, err := ops.PiVersion(); err == nil {
+		res.piVersion = strings.TrimSpace(version)
+		res.piVersionOK = piVersionAtLeast(res.piVersion, piVersionFloor)
+	}
 	return res
 }
 
 func piRuntimeLaunchReady(c piCheckResult) bool {
-	return c.piBinOK && c.extensionOK && c.subagentsSkillOK && c.subagentsIntercomBridgeOK && c.intercomPackageOK && c.intercomSkillOK && c.spacedockPackageOK
+	return c.piBinOK && c.extensionOK && c.subagentsSkillOK && c.subagentsIntercomBridgeOK && c.intercomPackageOK && c.intercomSkillOK && c.spacedockPackageOK && c.firstOfficerSkillOK && c.spacedockExtensionOK && c.piVersionOK
+}
+
+// piVersionAtLeast reports whether version parses at or above floor (the
+// binary prints a bare semver). Unparseable output fails closed.
+func piVersionAtLeast(version, floor string) bool {
+	parse := func(v string) (int, int, int, bool) {
+		m := regexp.MustCompile(`(\d+)\.(\d+)(?:\.(\d+))?`).FindStringSubmatch(v)
+		if m == nil {
+			return 0, 0, 0, false
+		}
+		major, _ := strconv.Atoi(m[1])
+		minor, _ := strconv.Atoi(m[2])
+		patch := 0
+		if m[3] != "" {
+			patch, _ = strconv.Atoi(m[3])
+		}
+		return major, minor, patch, true
+	}
+	vm, vn, vp, ok := parse(version)
+	if !ok {
+		return false
+	}
+	fm, fn, fp, ok := parse(floor)
+	if !ok {
+		return false
+	}
+	if vm != fm {
+		return vm > fm
+	}
+	if vn != fn {
+		return vn > fn
+	}
+	return vp >= fp
+}
+
+// piLaunchWarnings returns the non-fatal launch warnings for a ready runtime:
+// duplicate spacedock registration (route-aware count) and the dev-override
+// double-extension load, each naming the roots and the `pi remove` remedy.
+func piLaunchWarnings(c piCheckResult) []string {
+	var warnings []string
+	if s := c.packageStatus; s.spacedockEntries > 1 {
+		roots := make([]string, 0, len(s.packageRoots))
+		for i, root := range s.packageRoots {
+			if i == 0 {
+				roots = append(roots, root+" (wins, first match)")
+				continue
+			}
+			roots = append(roots, root)
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"Spacedock is registered %d times in pi settings.json (%s): route-aware, up to %d skill registrations per skill name — each package registers via the manifest pi.skills scan AND the extension's resources_discover. First match wins: %s. Remedy: `pi remove` the stale entry.",
+			s.spacedockEntries, strings.Join(roots, "; "), s.spacedockEntries*piSkillRoutesPerPackage, s.packageRoot))
+	}
+	if c.doubleExtensionLoad {
+		warnings = append(warnings, fmt.Sprintf(
+			"dev override active (%s) AND a Spacedock package registered (%s): both extension copies load — the checkout's spacedock.ts via --extension, the installed one via package discovery. Remedy: `pi remove` the stale entry or drop the dev override.",
+			c.repoRoot, c.packageStatus.packageRoot))
+	}
+	return warnings
 }
 
 func piDoctorHealthy(c piCheckResult) bool {
@@ -635,6 +757,22 @@ func printPiDoctorReport(w io.Writer, c piCheckResult) {
 	printPiCheck(w, c.intercomPackageOK, "pi-intercom package root", c.intercomPackageRoot, "set PI_INTERCOM_PACKAGE_ROOT to the installed pi-intercom package root")
 	printPiCheck(w, c.intercomSkillOK, "pi-intercom skill", filepath.Join(c.intercomPackageRoot, "skills", "pi-intercom"), "install pi-intercom or set PI_INTERCOM_PACKAGE_ROOT to a package root containing skills/pi-intercom/SKILL.md")
 	printPiCheck(w, c.spacedockPackageOK, "Spacedock package", piPackageReportPath(c.packageStatus), "run `spacedock install --host pi` to install the Spacedock package (or `spacedock install --host pi --plugin-dir <checkout>` for a dev override)")
+	printPiCheck(w, c.spacedockExtensionOK, "Spacedock extension", filepath.Join(piPackageReportPath(c.packageStatus), ".pi", "extensions", "spacedock.ts"), "run `spacedock install --host pi` to reinstall the Spacedock package (its .pi/extensions/spacedock.ts delivers the FO contract)")
+	printPiCheck(w, c.firstOfficerSkillOK, "Spacedock first-officer skill (package discovery)", filepath.Join(piPackageReportPath(c.packageStatus), "skills", "first-officer"), "run `spacedock install --host pi` to reinstall the Spacedock package")
+	if c.piVersionOK {
+		fmt.Fprintf(w, "OK pi version: %s (floor %s)\n", c.piVersion, piVersionFloor)
+	} else {
+		fmt.Fprintf(w, "MISSING pi version: %s (floor %s)\n", c.piVersion, piVersionFloor)
+		fmt.Fprintln(w, "  remedy: upgrade Pi — `npm install -g @earendil-works/pi-coding-agent` (pi now publishes as @earendil-works; a sub-floor binary is the stale @mariozechner-org install)")
+	}
+	if s := c.packageStatus; s.spacedockEntries > 1 {
+		fmt.Fprintf(w, "WARN duplicate Spacedock registration: %d package entries (%s) — route-aware, up to %d skill registrations per skill name (manifest pi.skills scan + extension resources_discover); first match wins: %s\n", s.spacedockEntries, strings.Join(s.packageRoots, "; "), s.spacedockEntries*piSkillRoutesPerPackage, s.packageRoot)
+		fmt.Fprintln(w, "  remedy: `pi remove` the stale entry")
+	}
+	if c.doubleExtensionLoad {
+		fmt.Fprintf(w, "WARN dev-override double extension: %s loads via --extension AND the registered package's spacedock.ts loads via package discovery (%s)\n", filepath.Join(c.repoRoot, ".pi", "extensions", "spacedock.ts"), c.packageStatus.packageRoot)
+		fmt.Fprintln(w, "  remedy: `pi remove` the stale entry or drop the dev override")
+	}
 	printPiSupervisorTalkbackBoundary(w)
 }
 
@@ -687,12 +825,10 @@ func envMap(env []string) map[string]string {
 }
 
 // piSpacedockPackageStatus replicates the package-registration + skill-discovery
-// contract that pi-subagents' collectSettingsPackageSkillPaths uses: it reads
-// ~/.pi/agent/settings.json `packages`, resolves each entry's package root (via
-// resolveSettingsPackageRoot), reads the package's package.json, and confirms a
-// package named "spacedock" is registered with ensign discoverable under its
-// pi.skills paths. This is the real discovery check — not a Stat of a cwd-derived
-// path — so it holds from a non-repo cwd once the package is installed.
+// contract that pi-subagents' collectSettingsPackageSkillPaths uses over
+// ~/.pi/agent/settings.json `packages` — the real discovery check, not a Stat
+// of a cwd-derived path. It also counts spacedock entries for the
+// route-aware duplicate condition (packages x registration routes).
 func piSpacedockPackageStatus(agentDir, home string) piPackageStatus {
 	if agentDir == "" {
 		return piPackageStatus{}
@@ -708,6 +844,7 @@ func piSpacedockPackageStatus(agentDir, home string) piPackageStatus {
 		return piPackageStatus{}
 	}
 	var st piPackageStatus
+	var spacedockRoots []string
 	for _, raw := range settings.Packages {
 		src := piPackageSourceFromEntry(raw)
 		if src == "" {
@@ -718,23 +855,30 @@ func piSpacedockPackageStatus(agentDir, home string) piPackageStatus {
 			continue
 		}
 		name, skillPaths := readPackagePiSkills(root)
-		if name == "spacedock" && !st.registered {
-			st.registered = true
-			st.source = src
-			st.packageRoot = root
-			for _, sp := range skillPaths {
-				dir := filepath.Join(root, sp)
-				if piSkillFileExists(dir, "ensign") {
-					st.ensignDiscoverable = true
-				}
-				if piSkillFileExists(dir, "first-officer") {
-					st.firstOfficerDiscoverable = true
+		if name == "spacedock" {
+			// First match wins (pi's skill scan is first-match by skill
+			// name); every entry counts toward the duplicate condition.
+			spacedockRoots = append(spacedockRoots, root)
+			if !st.registered {
+				st.registered = true
+				st.source = src
+				st.packageRoot = root
+				for _, sp := range skillPaths {
+					dir := filepath.Join(root, sp)
+					if piSkillFileExists(dir, "ensign") {
+						st.ensignDiscoverable = true
+					}
+					if piSkillFileExists(dir, "first-officer") {
+						st.firstOfficerDiscoverable = true
+					}
 				}
 			}
 		} else if name == "pi-subagents" {
 			st.subagentsRegistered = true
 		}
 	}
+	st.spacedockEntries = len(spacedockRoots)
+	st.packageRoots = spacedockRoots
 	return st
 }
 

--- a/internal/cli/pi_frontdoor_test.go
+++ b/internal/cli/pi_frontdoor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -23,6 +24,12 @@ type fakePiRuntimeOps struct {
 	piInstallOut  string
 	piInstallErr  error
 	packageStatus piPackageStatus
+	// piVersionOut/Err fake `pi --version`. Empty out with nil err means a
+	// healthy current binary (0.85.1, above the 0.83.0 floor) so the many
+	// existing fixtures don't each need a version field; sub-floor and
+	// garbage-version tests set it explicitly.
+	piVersionOut string
+	piVersionErr error
 }
 
 func (f *fakePiRuntimeOps) LookPath(name string) (string, error) {
@@ -52,6 +59,13 @@ func (f *fakePiRuntimeOps) PiInstall(source string) (string, error) {
 
 func (f *fakePiRuntimeOps) SpacedockPackageStatus(agentDir, home string) piPackageStatus {
 	return f.packageStatus
+}
+
+func (f *fakePiRuntimeOps) PiVersion() (string, error) {
+	if f.piVersionOut == "" && f.piVersionErr == nil {
+		return "0.85.1\n", nil
+	}
+	return f.piVersionOut, f.piVersionErr
 }
 
 // healthyPiPackageStatus is the canned status for a registered, discoverable
@@ -133,8 +147,18 @@ func TestPiFrontDoorLaunchesWithNativeResourcePaths(t *testing.T) {
 		t.Fatalf("pi launch argv must not pass retired repo skill flags: %v", ops.launched)
 	}
 	prompt := ops.launched[len(ops.launched)-1]
-	if !strings.Contains(prompt, "Use $spacedock:first-officer") || !strings.Contains(prompt, "review this") {
-		t.Fatalf("pi prompt missing FO skill or task: %q", prompt)
+	// The frontdoor launch prompt is argv-only now: the operator task lands as
+	// the launch prompt; the contract sentence is gone (the extension's gated
+	// injection owns the contract delivery).
+	if prompt != "review this" {
+		t.Fatalf("pi launch prompt = %q, want the bare operator task (no contract sentence)", prompt)
+	}
+	if strings.Contains(strings.Join(ops.launched, " "), "$spacedock:") {
+		t.Fatalf("pi launch argv must not carry $spacedock: syntax (unexpandable in a launch prompt): %v", ops.launched)
+	}
+	// The launch marker is set in the child env on every launch shape (AC-3/AC-4).
+	if !hasLaunchMarkerEnv(ops.launchedEnv) {
+		t.Fatalf("launched env missing %s=1: %v", piLaunchMarkerEnv, ops.launchedEnv)
 	}
 }
 
@@ -184,35 +208,35 @@ func TestRunPi_DevOverridePassesSpacedockExtensionAndSkills(t *testing.T) {
 	}
 }
 
-// TestRunPi_DevOverrideWithoutExtensionFallsBackGracefully pins the os.Stat
-// guard: when the dev-override is active but <repo>/.pi/extensions/spacedock.ts
-// is absent, runPi does NOT add the Spacedock extension/skill flags (no crash).
+// TestRunPi_DevOverrideWithoutExtensionFallsBackGracefully pins the ready-gate
+// tightening (AC-5a): when the dev-override is active but
+// <repo>/.pi/extensions/spacedock.ts is absent, runPi REFUSES (the not-ready
+// path) instead of silently launching a contract-less session — the old
+// graceful flag-drop launched a skill-less pi, the 2026-09-10 incident's
+// failure shape.
 func TestRunPi_DevOverrideWithoutExtensionFallsBackGracefully(t *testing.T) {
 	repo := t.TempDir()
 	writePiSkillFixtures(t, repo)
 	// NOTE: .pi/extensions/spacedock.ts intentionally NOT created.
 	pkg := t.TempDir()
 	writePiSubagentsFixtures(t, pkg)
+	statOK := statOKForPiResources(repo, pkg)
+	delete(statOK, filepath.Join(repo, ".pi", "extensions", "spacedock.ts"))
 	ops := &fakePiRuntimeOps{
 		lookPath:      piHealthyPathFixtures(),
-		statOK:        statOKForPiResources(repo, pkg),
-		packageStatus: healthyPiPackageStatus(),
+		statOK:        statOK,
+		packageStatus: piPackageStatus{}, // not registered: the dev-override fallback arm
 	}
 	var stdout, stderr bytes.Buffer
 	code := runPi(context.Background(), []string{"--plugin-dir", repo, "--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	if code != 1 {
+		t.Fatalf("exit=%d want 1 (not-ready refusal when the dev-override checkout has no Spacedock extension): stderr=%q", code, stderr.String())
 	}
-	joined := strings.Join(ops.launched, " ")
-	wantExt := filepath.Join(repo, ".pi", "extensions", "spacedock.ts")
-	if strings.Contains(joined, wantExt) {
-		t.Fatalf("dev-override argv must not reference absent extension %q: %v", wantExt, ops.launched)
+	if !strings.Contains(stdout.String(), "MISSING Spacedock extension") {
+		t.Fatalf("doctor report missing MISSING Spacedock extension line:\n%s", stdout.String())
 	}
-	if strings.Contains(joined, "--skill "+filepath.Join(repo, "skills")) {
-		t.Fatalf("dev-override argv must not add spacedock skills when extension absent: %v", ops.launched)
-	}
-	if got := strings.Count(joined, "--skill"); got != 1 {
-		t.Fatalf("expected exactly 1 --skill flag (pi-subagents only), got %d: %v", got, ops.launched)
+	if len(ops.launched) != 0 {
+		t.Fatalf("refused runtime must not launch: %v", ops.launched)
 	}
 }
 
@@ -225,6 +249,9 @@ func TestRunPi_DevOverrideWithoutExtensionFallsBackGracefully(t *testing.T) {
 func TestRunPi_InstalledPathDoesNotPassSpacedockExtension(t *testing.T) {
 	repo := t.TempDir()
 	writePiSkillFixtures(t, repo)
+	// The ready gate Stats the effective package root's extension (AC-5a);
+	// this test points packageRoot at the repo.
+	writeFileWithDirs(t, filepath.Join(repo, ".pi", "extensions", "spacedock.ts"), "export default function(){}\n")
 	pkg := t.TempDir()
 	writePiSubagentsFixtures(t, pkg)
 	// No --plugin-dir / SPACEDOCK_REPO_ROOT: installed path (cfg.repoRoot == "").
@@ -233,9 +260,11 @@ func TestRunPi_InstalledPathDoesNotPassSpacedockExtension(t *testing.T) {
 	status := healthyPiPackageStatus()
 	// Point the package root at the repo so the ensign skill Stat check resolves.
 	status.packageRoot = repo
+	statOK := statOKForPiResources(repo, pkg)
+	statOK[filepath.Join(repo, ".pi", "extensions", "spacedock.ts")] = true
 	ops := &fakePiRuntimeOps{
 		lookPath:      piHealthyPathFixtures(),
-		statOK:        statOKForPiResources(repo, pkg),
+		statOK:        statOK,
 		packageStatus: status,
 	}
 	var stdout, stderr bytes.Buffer
@@ -622,8 +651,11 @@ func TestPiDoctorReportsMissingAndHealthyRuntime(t *testing.T) {
 				t.Fatalf("healthy doctor output missing %q:\n%s", want, out)
 			}
 		}
-		// The retired repo-path skill checks must not appear.
-		for _, notWant := range []string{"OK Spacedock first-officer skill", "OK Spacedock ensign skill"} {
+		// The retired repo-path skill checks must not appear: the retired render
+		// was `OK Spacedock <skill> skill: <cwd-derived path>`. The package-
+		// discovery first-officer line (AC-7) uses a distinct label and is
+		// asserted in TestPiDoctorReportsFirstOfficerVersionDuplicates.
+		for _, notWant := range []string{"OK Spacedock first-officer skill: ", "OK Spacedock ensign skill"} {
 			if strings.Contains(out, notWant) {
 				t.Fatalf("healthy doctor output should not print retired skill check %q:\n%s", notWant, out)
 			}
@@ -640,6 +672,9 @@ func TestPiDoctorReportsMissingAndHealthyRuntime(t *testing.T) {
 func TestPiRuntimeDevOverrideSatisfiesPackageGate(t *testing.T) {
 	repo := t.TempDir()
 	writePiSkillFixtures(t, repo)
+	// The ready gate now also requires the effective package root's extension
+	// (AC-5a); give the dev-override checkout one.
+	writeFileWithDirs(t, filepath.Join(repo, ".pi", "extensions", "spacedock.ts"), "export default function(){}\n")
 	pkg := t.TempDir()
 	writePiSubagentsFixtures(t, pkg)
 
@@ -761,6 +796,12 @@ func statOKForPiResources(repo, pkg string) map[string]bool {
 		filepath.Join(pkg, "src", "intercom", "intercom-bridge.ts"): true,
 		filepath.Join(repo, "skills", "first-officer", "SKILL.md"):  true,
 		filepath.Join(repo, "skills", "ensign", "SKILL.md"):         true,
+		// The repo (dev-override) extension: the ready gate Stats the
+		// effective package root's extension (AC-5a).
+		filepath.Join(repo, ".pi", "extensions", "spacedock.ts"): true,
+		// healthyPiPackageStatus's package root — same gate for the installed
+		// package root.
+		filepath.Join("/pkg-store/spacedock", ".pi", "extensions", "spacedock.ts"): true,
 		pkg + "-intercom": true,
 		filepath.Join(pkg+"-intercom", "skills", "pi-intercom", "SKILL.md"): true,
 	}
@@ -884,8 +925,11 @@ func TestPiFrontDoorWrapsWhenKnobPresent(t *testing.T) {
 	// Feedback cycle 2: pi now mirrors claude/codex's wrap plumbing —
 	// launcherBinEnvPassFlags() prefixes the safehouse extra with --env-pass
 	// SPACEDOCK_BIN (AC-4) so the launcher the helper calls resolve survives the
-	// sandbox boundary. The operator's add-dirs follows.
+	// sandbox boundary. The operator's add-dirs follows. Pi adds its own
+	// --env-pass PI_SPACEDOCK_LAUNCH so the gated extension's marker survives
+	// the sandbox boundary too.
 	wantExtra = append(launcherBinEnvPassFlags(), wantExtra...)
+	wantExtra = append(wantExtra, "--env-pass", piLaunchMarkerEnv)
 	if !equalArgv(piSafehouseExtra(ops.launched), wantExtra) {
 		t.Fatalf("extra = %v, want TranslateFlags output prefixed by launcherBinEnvPassFlags %v\nargv=%v", piSafehouseExtra(ops.launched), wantExtra, ops.launched)
 	}
@@ -899,8 +943,8 @@ func TestPiFrontDoorWrapsWhenKnobPresent(t *testing.T) {
 		"--extension", filepath.Join(pkg, "src", "extension", "index.ts"),
 		"--skill", filepath.Join(pkg, "skills", "pi-subagents"),
 	}
-	if len(inner) < len(wantPrefix)+1 {
-		t.Fatalf("wrapped inner argv too short: %v", inner)
+	if len(inner) != len(wantPrefix) {
+		t.Fatalf("wrapped inner argv = %v, want exactly the prefix (no launch prompt — argv-only now, no task in this launch)", inner)
 	}
 	for i, want := range wantPrefix {
 		if inner[i] != want {
@@ -947,8 +991,9 @@ func TestPiFrontDoorWrapsWhenSafehouseProfileAlone(t *testing.T) {
 	if len(ops.launched) == 0 || ops.launched[0] != "safehouse" {
 		t.Fatalf("expected safehouse-wrapped argv for .safehouse profile alone, got %v", ops.launched)
 	}
-	if !equalArgv(piSafehouseExtra(ops.launched), launcherBinEnvPassFlags()) {
-		t.Fatalf("extra should be just launcherBinEnvPassFlags for profile-alone wrap, got %v", piSafehouseExtra(ops.launched))
+	wantProfileAlone := append(launcherBinEnvPassFlags(), "--env-pass", piLaunchMarkerEnv)
+	if !equalArgv(piSafehouseExtra(ops.launched), wantProfileAlone) {
+		t.Fatalf("extra should be launcherBinEnvPassFlags + the pi launch marker env-pass for profile-alone wrap, got %v", piSafehouseExtra(ops.launched))
 	}
 }
 
@@ -1106,11 +1151,13 @@ func TestPiSpacedockPackageStatus_SubagentsRegistered(t *testing.T) {
 	}
 }
 
-// TestPiResumeSuppressesBootstrapPrompt pins AC-1/AC-2: a Pi launch with a resume
-// token in the passthrough (--resume, --resume=<id>, -r, --continue, -c) must
-// NOT append piBootstrapPrompt to the argv, while a non-resume launch still
-// does. The non-resume case is the independent baseline that can move the wrong
-// way (if the gate regresses or the non-resume path loses the prompt).
+// TestPiResumeSuppressesBootstrapPrompt pins AC-3's resume arm: a Pi launch
+// with a resume token in the passthrough (--resume, --resume=<id>, -r,
+// --continue, -c) appends NO launch prompt, and no launch shape ever carries
+// $spacedock: contract syntax (the extension's gated injection owns the
+// contract). The non-resume cases are the independent baselines that can move
+// the wrong way: a task still lands as the bare launch prompt, and a
+// non-task passthrough appends nothing.
 func TestPiResumeSuppressesBootstrapPrompt(t *testing.T) {
 	resumeTokens := []string{
 		"--resume",
@@ -1137,8 +1184,8 @@ func TestPiResumeSuppressesBootstrapPrompt(t *testing.T) {
 				t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 			}
 			for _, tok := range ops.launched {
-				if strings.Contains(tok, piBootstrapPrompt) {
-					t.Fatalf("resume token %q: argv contains piBootstrapPrompt: %v", token, ops.launched)
+				if strings.Contains(tok, "$spacedock:") {
+					t.Fatalf("resume token %q: argv contains $spacedock: contract syntax: %v", token, ops.launched)
 				}
 			}
 		})
@@ -1168,10 +1215,377 @@ func TestPiResumeSuppressesBootstrapPrompt(t *testing.T) {
 			if code != 0 {
 				t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 			}
-			prompt := ops.launched[len(ops.launched)-1]
-			if !strings.Contains(prompt, piBootstrapPrompt) {
-				t.Fatalf("non-resume passthrough %v: last argv token missing piBootstrapPrompt: %v", tc.passthru, ops.launched)
+			for _, tok := range ops.launched {
+				if strings.Contains(tok, "$spacedock:") {
+					t.Fatalf("non-resume passthrough %v: argv contains $spacedock: contract syntax: %v", tc.passthru, ops.launched)
+				}
+			}
+			last := ops.launched[len(ops.launched)-1]
+			switch tc.name {
+			case "task_string":
+				if last != "review this code" {
+					t.Fatalf("non-resume task: last argv = %q, want the bare task (no contract sentence)", last)
+				}
+			case "model_flag":
+				// A flag passthrough appends no prompt: the argv tail stays the flags.
+				if last != "google/gemini" {
+					t.Fatalf("non-resume flag passthrough: unexpected argv tail %q (a prompt was appended?)", last)
+				}
 			}
 		})
+	}
+}
+
+// hasLaunchMarkerEnv reports whether env carries PI_SPACEDOCK_LAUNCH=1.
+func hasLaunchMarkerEnv(env []string) bool {
+	for _, kv := range env {
+		if kv == piLaunchMarkerEnv+"=1" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRunPi_SetsLaunchMarkerEnvOnEveryLaunchShape pins AC-3's dev-override arm:
+// PI_SPACEDOCK_LAUNCH=1 is in the launched child env with AND without repoRoot
+// set. Falsifying edit: drop the env append in runPi.
+func TestRunPi_SetsLaunchMarkerEnvOnEveryLaunchShape(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"installed", []string{"--", "--version"}},
+		{"dev_override", []string{"--plugin-dir", "REPO", "--", "--version"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writePiSkillFixtures(t, repo)
+			writeFileWithDirs(t, filepath.Join(repo, ".pi", "extensions", "spacedock.ts"), "export default function(){}\n")
+			pkg := t.TempDir()
+			writePiSubagentsFixtures(t, pkg)
+			ops := &fakePiRuntimeOps{
+				lookPath:      piHealthyPathFixtures(),
+				statOK:        statOKForPiResources(repo, pkg),
+				packageStatus: healthyPiPackageStatus(),
+			}
+			var stdout, stderr bytes.Buffer
+			args := make([]string, 0, len(tc.args))
+			for _, a := range tc.args {
+				if a == "REPO" {
+					args = append(args, repo)
+					continue
+				}
+				args = append(args, a)
+			}
+			code := runPi(context.Background(), args, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+			}
+			if !hasLaunchMarkerEnv(ops.launchedEnv) {
+				t.Fatalf("%s: launched env missing %s=1: %v", tc.name, piLaunchMarkerEnv, ops.launchedEnv)
+			}
+		})
+	}
+}
+
+// TestRunPi_ReadyGateRequiresSpacedockExtension pins AC-5a: the ready gate
+// refuses when the package root's .pi/extensions/spacedock.ts is missing.
+func TestRunPi_ReadyGateRequiresSpacedockExtension(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	statOK := statOKForPiResources(repo, pkg)
+	delete(statOK, filepath.Join("/pkg-store/spacedock", ".pi", "extensions", "spacedock.ts"))
+	ops := &fakePiRuntimeOps{
+		lookPath:      piHealthyPathFixtures(),
+		statOK:        statOK,
+		packageStatus: healthyPiPackageStatus(),
+	}
+	var stdout, stderr bytes.Buffer
+	code := runPi(context.Background(), []string{"--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit=%d want 1 (missing installed Spacedock extension must refuse): stdout=%q", code, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "MISSING Spacedock extension") {
+		t.Fatalf("doctor report missing MISSING Spacedock extension line:\n%s", stdout.String())
+	}
+	if len(ops.launched) != 0 {
+		t.Fatalf("refused runtime must not launch: %v", ops.launched)
+	}
+}
+
+// TestRunPi_ReadyGateRequiresFirstOfficerSkill pins AC-5b: the ready gate
+// refuses when first-officer is not discoverable from the package.
+func TestRunPi_ReadyGateRequiresFirstOfficerSkill(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	status := healthyPiPackageStatus()
+	status.firstOfficerDiscoverable = false
+	ops := &fakePiRuntimeOps{
+		lookPath:      piHealthyPathFixtures(),
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: status,
+	}
+	var stdout, stderr bytes.Buffer
+	code := runPi(context.Background(), []string{"--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit=%d want 1 (undiscoverable first-officer must refuse): stdout=%q", code, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "MISSING Spacedock first-officer skill") {
+		t.Fatalf("doctor report missing MISSING first-officer line:\n%s", stdout.String())
+	}
+	if len(ops.launched) != 0 {
+		t.Fatalf("refused runtime must not launch: %v", ops.launched)
+	}
+}
+
+// TestRunPi_ReadyGateRefusesSubFloorPiVersion pins AC-5's pi >= 0.83.0 floor,
+// read from the binary's `pi --version` only; unparseable output fails closed.
+func TestRunPi_ReadyGateRefusesSubFloorPiVersion(t *testing.T) {
+	cases := []struct {
+		version string
+		want    int
+	}{
+		{"0.82.9", 1},
+		{"0.83.0", 0},
+		{"0.85.1", 0},
+		{"1.0.0", 0},
+		{"dev\n", 1},   // unparseable fails closed
+		{"garbage", 1}, // unparseable fails closed
+	}
+	for _, tc := range cases {
+		t.Run(tc.version, func(t *testing.T) {
+			repo := t.TempDir()
+			writePiSkillFixtures(t, repo)
+			pkg := t.TempDir()
+			writePiSubagentsFixtures(t, pkg)
+			ops := &fakePiRuntimeOps{
+				lookPath:      piHealthyPathFixtures(),
+				statOK:        statOKForPiResources(repo, pkg),
+				packageStatus: healthyPiPackageStatus(),
+				piVersionOut:  tc.version,
+			}
+			var stdout, stderr bytes.Buffer
+			code := runPi(context.Background(), []string{"--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+			if code != tc.want {
+				t.Fatalf("pi version %q: exit=%d want %d (stdout=%q)", tc.version, code, tc.want, stdout.String())
+			}
+			if tc.want != 0 && !strings.Contains(stdout.String(), "MISSING pi version") {
+				t.Fatalf("sub-floor doctor report missing MISSING pi version line:\n%s", stdout.String())
+			}
+		})
+	}
+}
+
+// TestPiVersionAtLeast unit-tests the floor parse directly: bare semver in,
+// floor compare, fail closed on garbage.
+func TestPiVersionAtLeast(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"0.82.9", false},
+		{"0.83.0", true},
+		{"0.83.1", true},
+		{"0.85.1", true},
+		{"1.0.0", true},
+		{"0.8.9", false},
+		{"0.9.0", false},
+		{"", false},
+		{"dev", false},
+		{"garbage 0.90.0 trailing", true}, // first semver triple in the output wins
+	}
+	for _, tc := range cases {
+		if got := piVersionAtLeast(tc.version, piVersionFloor); got != tc.want {
+			t.Errorf("piVersionAtLeast(%q, %q) = %v, want %v", tc.version, piVersionFloor, got, tc.want)
+		}
+	}
+}
+
+// TestRunPi_WarnsOnDuplicateSpacedockRegistration pins AC-5's non-fatal
+// duplicate warning: all roots, the first-match winner, the route-aware count.
+func TestRunPi_WarnsOnDuplicateSpacedockRegistration(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	status := healthyPiPackageStatus()
+	status.spacedockEntries = 2
+	status.packageRoots = []string{"/pkg-store/spacedock", "/dev-link/spacedock"}
+	ops := &fakePiRuntimeOps{
+		lookPath:      piHealthyPathFixtures(),
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: status,
+	}
+	var stdout, stderr bytes.Buffer
+	code := runPi(context.Background(), []string{"--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("duplicate registration is non-fatal: exit=%d stderr=%q", code, stderr.String())
+	}
+	warnings := stderr.String()
+	for _, want := range []string{
+		"registered 2 times",
+		"/pkg-store/spacedock (wins, first match)",
+		"/dev-link/spacedock",
+		"up to 4 skill registrations",
+		"pi remove",
+	} {
+		if !strings.Contains(warnings, want) {
+			t.Fatalf("duplicate-registration warning missing %q:\n%s", want, warnings)
+		}
+	}
+}
+
+// TestRunPi_WarnsOnDevOverrideDoubleExtension pins AC-5's non-fatal warning on
+// the static dev-override double-extension condition (repoRoot + registered).
+func TestRunPi_WarnsOnDevOverrideDoubleExtension(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	writeFileWithDirs(t, filepath.Join(repo, ".pi", "extensions", "spacedock.ts"), "export default function(){}\n")
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	ops := &fakePiRuntimeOps{
+		lookPath:      piHealthyPathFixtures(),
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: healthyPiPackageStatus(),
+	}
+	var stdout, stderr bytes.Buffer
+	code := runPi(context.Background(), []string{"--plugin-dir", repo, "--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("double extension is non-fatal: exit=%d stderr=%q", code, stderr.String())
+	}
+	warnings := stderr.String()
+	for _, want := range []string{"both extension copies load", repo, "pi remove"} {
+		if !strings.Contains(warnings, want) {
+			t.Fatalf("double-extension warning missing %q:\n%s", want, warnings)
+		}
+	}
+}
+
+// TestPiDoctorReportsFirstOfficerVersionDuplicates pins AC-7: the first-officer
+// skill line, the pi version floor line (sub-floor flagged as the stale
+// @mariozechner-org signal with an @earendil-works remedy), the route-aware
+// duplicate count and the double-extension line, each with `pi remove`.
+func TestPiDoctorReportsFirstOfficerVersionDuplicates(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	home := t.TempDir()
+
+	t.Run("healthy floors and duplicates flagged", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		auth := filepath.Join(home, ".pi", "agent", "auth.json")
+		statOK := statOKForPiResources(repo, pkg)
+		statOK[auth] = true
+		status := healthyPiPackageStatus()
+		status.spacedockEntries = 2
+		status.packageRoots = []string{"/pkg-store/spacedock", "/dev-link/spacedock"}
+		code := runDoctorWithPi(context.Background(), []string{"--host", "pi", "--plugin-dir", repo}, &fakeHost{}, &fakePiRuntimeOps{
+			lookPath:      piHealthyPathFixtures(),
+			statOK:        statOK,
+			packageStatus: status,
+			// repoRoot is derived from --plugin-dir; the double-extension
+			// condition is repoRoot set AND the package registered.
+		}, piTestEnv(pkg, home), &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+		}
+		out := stdout.String()
+		for _, want := range []string{
+			"OK Spacedock first-officer skill (package discovery)",
+			"OK Spacedock extension",
+			"OK pi version: 0.85.1 (floor 0.83.0)",
+			"WARN duplicate Spacedock registration: 2 package entries",
+			"up to 4 skill registrations",
+			"remedy: `pi remove` the stale entry",
+			"WARN dev-override double extension",
+		} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("doctor output missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("sub-floor version flagged as stale-org signal", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := runDoctorWithPi(context.Background(), []string{"--host", "pi", "--plugin-dir", repo}, &fakeHost{}, &fakePiRuntimeOps{
+			lookPath:      piHealthyPathFixtures(),
+			statOK:        statOKForPiResources(repo, pkg),
+			packageStatus: healthyPiPackageStatus(),
+			piVersionOut:  "0.73.1\n",
+		}, piTestEnv(pkg, home), &stdout, &stderr)
+		if code == 0 {
+			t.Fatalf("sub-floor doctor must exit non-zero:\n%s", stdout.String())
+		}
+		out := stdout.String()
+		for _, want := range []string{
+			"MISSING pi version: 0.73.1 (floor 0.83.0)",
+			"@earendil-works",
+			"@mariozechner",
+		} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("sub-floor doctor output missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("missing first-officer and extension lines", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		status := healthyPiPackageStatus()
+		status.firstOfficerDiscoverable = false
+		statOK := statOKForPiResources(repo, pkg)
+		delete(statOK, filepath.Join("/pkg-store/spacedock", ".pi", "extensions", "spacedock.ts"))
+		code := runDoctorWithPi(context.Background(), []string{"--host", "pi", "--plugin-dir", repo}, &fakeHost{}, &fakePiRuntimeOps{
+			lookPath:      piHealthyPathFixtures(),
+			statOK:        statOK,
+			packageStatus: status,
+		}, piTestEnv(pkg, home), &stdout, &stderr)
+		if code == 0 {
+			t.Fatalf("doctor must exit non-zero when the FO contract path is broken:\n%s", stdout.String())
+		}
+		out := stdout.String()
+		for _, want := range []string{"MISSING Spacedock extension", "MISSING Spacedock first-officer skill"} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("doctor output missing %q:\n%s", want, out)
+			}
+		}
+	})
+}
+
+// TestPiSpacedockPackageStatus_DoubleRegistration pins the route-aware
+// duplicate detection at the source: two spacedock entries → spacedockEntries=2,
+// packageRoots in settings order (first wins), discovery from the first only.
+func TestPiSpacedockPackageStatus_DoubleRegistration(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+	for _, root := range []string{first, second} {
+		writeFileWithDirs(t, filepath.Join(root, "package.json"), `{"name":"spacedock","pi":{"skills":["./skills"]}}`)
+		writeFileWithDirs(t, filepath.Join(root, "skills", "ensign", "SKILL.md"), "---\nname: ensign\ndescription: test\n---\n")
+	}
+	// Only the first root carries first-officer — the winner's discovery is
+	// what counts.
+	writeFileWithDirs(t, filepath.Join(first, "skills", "first-officer", "SKILL.md"), "---\nname: first-officer\ndescription: test\n---\n")
+	agentDir := t.TempDir()
+	writeFile(t, filepath.Join(agentDir, "settings.json"), fmt.Sprintf(`{"packages":["%s","%s"]}`, first, second))
+	status := piSpacedockPackageStatus(agentDir, t.TempDir())
+	if !status.registered {
+		t.Fatalf("spacedock package should be registered")
+	}
+	if status.spacedockEntries != 2 {
+		t.Fatalf("spacedockEntries = %d, want 2", status.spacedockEntries)
+	}
+	if len(status.packageRoots) != 2 || status.packageRoots[0] != first || status.packageRoots[1] != second {
+		t.Fatalf("packageRoots = %v, want [%q %q] (settings order, first wins)", status.packageRoots, first, second)
+	}
+	if status.packageRoot != first {
+		t.Fatalf("packageRoot = %q, want the first entry %q (first-match winner)", status.packageRoot, first)
+	}
+	if !status.firstOfficerDiscoverable {
+		t.Fatalf("first-officer should be discoverable from the winning (first) root")
 	}
 }

--- a/internal/cli/pi_launch_test.go
+++ b/internal/cli/pi_launch_test.go
@@ -383,3 +383,46 @@ func TestRunPi_LaunchArgv0_UnchangedForDirect(t *testing.T) {
 		t.Fatalf("launched argv[0]=%q, want \"pi\" (unchanged)\nargv=%v", got, ops.launched)
 	}
 }
+
+// TestRunPi_WrapCarriesLaunchMarker pins AC-4's wrap arm: under the safehouse
+// wrap, the launched (safehouse) env carries PI_SPACEDOCK_LAUNCH=1 and the
+// safehouse extra carries --env-pass PI_SPACEDOCK_LAUNCH so the marker reaches
+// the sandboxed pi child and the extension's gated injection fires on wrapped
+// launches too. The falsifying edit drops either the env append or the
+// --env-pass flag in runPi.
+func TestRunPi_WrapCarriesLaunchMarker(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	ops := &fakePiRuntimeOps{
+		lookPath: map[string]string{
+			"pi":        "/usr/local/bin/pi",
+			"safehouse": "/bin/safehouse",
+		},
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: healthyPiPackageStatus(),
+	}
+	var stdout, stderr bytes.Buffer
+	code := runPi(context.Background(), []string{"--plugin-dir", repo, "--safehouse", "--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runPi exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if len(ops.launched) == 0 || ops.launched[0] != "safehouse" {
+		t.Fatalf("expected safehouse-wrapped argv, got %v", ops.launched)
+	}
+	if !hasLaunchMarkerEnv(ops.launchedEnv) {
+		t.Fatalf("safehouse process env missing %s=1: %v", piLaunchMarkerEnv, ops.launchedEnv)
+	}
+	extra := piSafehouseExtra(ops.launched)
+	found := false
+	for i, flag := range extra {
+		if flag == "--env-pass" && i+1 < len(extra) && extra[i+1] == piLaunchMarkerEnv {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("safehouse extra missing --env-pass %s (the marker would not reach the sandboxed pi)\nextra=%v", piLaunchMarkerEnv, extra)
+	}
+}

--- a/internal/cli/safehouse_frontdoor_test.go
+++ b/internal/cli/safehouse_frontdoor_test.go
@@ -427,8 +427,9 @@ func TestClaudeResumeFamilySuppressesBootstrapPrompt(t *testing.T) {
 
 // AC-3: the launch flourish is gone. Now that `engage` is a real captain-invoked
 // verb, no bootstrap prompt carries the throwaway "Engage." that would collide
-// with it. All three (claude, codex, pi) are covered so a flourish regression on
-// any is caught here, not only by git-diff emptiness (pi de-risks the 7v parity).
+// with it. Claude and Codex keep a bootstrap prompt const; pi's is REMOVED
+// entirely (the pi frontdoor launch prompt is argv-only now — the extension's
+// gated injection owns the contract delivery), so only claude/codex are covered.
 func TestBootstrapPromptsDropEngageFlourish(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
@@ -436,7 +437,6 @@ func TestBootstrapPromptsDropEngageFlourish(t *testing.T) {
 	}{
 		{"claude", bootstrapPrompt},
 		{"codex", codexBootstrapPrompt},
-		{"pi", piBootstrapPrompt},
 	} {
 		if strings.Contains(tc.prompt, "Engage.") {
 			t.Errorf("%s bootstrap prompt still carries the Engage. flourish: %q", tc.name, tc.prompt)

--- a/internal/piruntime/spacedock_extension_test.go
+++ b/internal/piruntime/spacedock_extension_test.go
@@ -23,14 +23,18 @@ func TestSpacedockPiExtensionBootstrapBehavior(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	modulePath := filepath.Join(tmp, "spacedock-extension.mjs")
+	modulePath := filepath.Join(tmp, ".pi", "extensions", "spacedock-extension.mjs")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatalf("stage extension dir: %v", err)
+	}
 	if err := os.WriteFile(modulePath, extensionSource, 0o644); err != nil {
 		t.Fatalf("write harness module: %v", err)
 	}
 
 	harnessPath := filepath.Join(tmp, "harness.mjs")
 	harness := `
-import register from './spacedock-extension.mjs';
+import register from './.pi/extensions/spacedock-extension.mjs';
+import * as fs from 'node:fs';
 
 const handlers = new Map();
 const execCalls = [];
@@ -51,15 +55,30 @@ const textOf = (message) => Array.isArray(message?.content)
 const countBootstraps = (messages) => messages.filter((message) => message?.role === 'user' && textOf(message).startsWith('<EXTREMELY_IMPORTANT>') && textOf(message).includes(marker)).length;
 const countBootRecords = (messages) => messages.filter((message) => message?.role === 'user' && textOf(message).includes(bootRecordMarker)).length;
 const assert = (condition, message) => { if (!condition) throw new Error(message); };
+// The real pi contract runs this extension under a frontdoor launch, where
+// the spacedock launcher sets PI_SPACEDOCK_LAUNCH=1 in the child env. Pin it
+// here so an inherited (or absent) marker on the host shell cannot flip the
+// gate.
+assert(process.env.PI_SPACEDOCK_LAUNCH === '1', 'harness must run under the frontdoor launch marker');
 
-const resources = handlers.get('resources_discover')({ type: 'resources_discover', cwd: process.cwd(), reason: 'test' });
-assert(resources.skillPaths.length === 1 && resources.skillPaths[0].endsWith('/skills'), 'resources_discover returns the package skills directory');
+// The real pi contract loads this extension from the registered package root,
+// where package.json declares pi.skills: ["./skills"]. The module is staged
+// bare in tmp, so first exercise the undeclared arm, then stage the manifest
+// and assert the manifest-skip (AC-4: no skillPaths for manifest-declared dirs).
+const manifestPath = new URL('./package.json', import.meta.url).pathname;
+let resources = handlers.get('resources_discover')({ type: 'resources_discover', cwd: process.cwd(), reason: 'test' });
+assert(resources.skillPaths.length === 1 && resources.skillPaths[0].endsWith('/skills'), 'resources_discover returns the package skills directory when the manifest does not declare it');
+fs.writeFileSync(manifestPath, JSON.stringify({ pi: { skills: ['./skills'] } }));
+resources = handlers.get('resources_discover')({ type: 'resources_discover', cwd: process.cwd(), reason: 'test' });
+assert(resources.skillPaths.length === 0, 'resources_discover skips the skills dir the package manifest already declares');
 
 // --- session_start path (AC-3: unchanged) ---
 handlers.get('session_start')({ type: 'session_start' });
 let first = await handlers.get('context')({ messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }] });
 assert(countBootstraps(first.messages) === 1, 'session_start injects exactly one structural bootstrap');
-assert(textOf(first.messages[0]).includes('Load the $spacedock:first-officer skill'), 'bootstrap points at the shipped first-officer contract');
+assert(textOf(first.messages[0]).includes('[SPACEDOCK-FO-BOOTSTRAP-v1]'), 'bootstrap carries the FO bootstrap marker');
+assert(textOf(first.messages[0]).includes('<available_skills>'), 'bootstrap points at the resolvable <available_skills> trigger');
+assert(!textOf(first.messages[0]).includes('$spacedock:'), 'bootstrap uses no unexpandable $spacedock: syntax');
 assert(textOf(first.messages[0]).includes('Pi tool mapping: read/write/edit/bash/grep/find/ls'), 'bootstrap includes the Pi tool mapping');
 
 // --- session_compact path (AC-1 value-measuring, AC-2 mechanism) ---
@@ -75,7 +94,7 @@ assert(afterCompact.messages[0] === compactSummary, 'boot record is inserted aft
 const bootRecordText = textOf(afterCompact.messages[1]);
 assert(bootRecordText.includes('"command":"boot"'), 'compaction injects the boot record (command:boot)');
 assert(!bootRecordText.includes(marker), 'compaction does NOT inject the FO bootstrap marker');
-assert(!bootRecordText.includes('Load the $spacedock:first-officer skill'), 'compaction does NOT inject the contract pointer');
+assert(!bootRecordText.includes('<available_skills>'), 'compaction does NOT inject the contract pointer');
 // AC-2: pi.exec called with the right args
 assert(execCalls.length === 1, 'pi.exec called exactly once for the boot read');
 assert(execCalls[0].command === 'spacedock', 'pi.exec called with spacedock');
@@ -97,10 +116,12 @@ assert(suppressed === undefined, 'agent_end suppresses further injection');
 
 	cmd := exec.Command(node, harnessPath)
 	cmd.Dir = repoRoot
-	// The unset marker run must be genuinely unset: a pi-subagents child shell
-	// exports PI_SUBAGENT_CHILD, and an inherited marker would silently flip the
-	// exemption inside the harness process.
-	cmd.Env = harnessEnv(nil, "PI_SUBAGENT_CHILD")
+	// The unset subagent marker must be genuinely unset: a pi-subagents child
+	// shell exports PI_SUBAGENT_CHILD, and an inherited marker would silently
+	// flip the exemption inside the harness process. The frontdoor launch
+	// marker is pinned ON: the real pi contract runs this extension under a
+	// frontdoor launch, and the injection gate reads it at handler time.
+	cmd.Env = harnessEnv(map[string]string{"PI_SPACEDOCK_LAUNCH": "1"}, "PI_SUBAGENT_CHILD")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("extension behavior harness failed: %v\n%s", err, out)
@@ -110,7 +131,9 @@ assert(suppressed === undefined, 'agent_end suppresses further injection');
 // TestSpacedockPiExtensionChildExemption is the AC-1 child-session half: a
 // pi-subagents child (PI_SUBAGENT_CHILD=1) is a delegated worker, not a first
 // officer, so the context hook must inject zero FO bootstrap across
-// session_start and session_compact. Skill discovery is unaffected.
+// session_start and session_compact. Skill discovery is unaffected. The run
+// pins PI_SPACEDOCK_LAUNCH=1 as well, proving the child exemption dominates
+// the frontdoor marker and that neither marker state is inherited by accident.
 func TestSpacedockPiExtensionChildExemption(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {
@@ -123,7 +146,7 @@ func TestSpacedockPiExtensionChildExemption(t *testing.T) {
 
 	harnessPath := filepath.Join(tmp, "harness-child.mjs")
 	harness := `
-import register from './spacedock-extension.mjs';
+import register from './.pi/extensions/spacedock-extension.mjs';
 
 const handlers = new Map();
 const pi = {
@@ -134,6 +157,7 @@ register(pi);
 
 const assert = (condition, message) => { if (!condition) throw new Error(message); };
 assert(process.env.PI_SUBAGENT_CHILD === '1', 'harness must run under the subagent-child marker');
+assert(process.env.PI_SPACEDOCK_LAUNCH === '1', 'child harness must pin the frontdoor launch marker');
 
 const resources = handlers.get('resources_discover')({ type: 'resources_discover', cwd: process.cwd(), reason: 'test' });
 assert(resources.skillPaths.length === 1 && resources.skillPaths[0].endsWith('/skills'), 'child sessions still discover the package skills directory');
@@ -152,7 +176,7 @@ assert(afterCompact === undefined, 'PI_SUBAGENT_CHILD=1 session_compact injects 
 
 	cmd := exec.Command(node, harnessPath)
 	cmd.Dir = repoRoot
-	cmd.Env = harnessEnv(map[string]string{"PI_SUBAGENT_CHILD": "1"})
+	cmd.Env = harnessEnv(map[string]string{"PI_SUBAGENT_CHILD": "1", "PI_SPACEDOCK_LAUNCH": "1"})
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("child-exemption harness failed: %v\n%s", err, out)
@@ -160,14 +184,20 @@ assert(afterCompact === undefined, 'PI_SUBAGENT_CHILD=1 session_compact injects 
 }
 
 // copyExtension stages the shipped .pi/extensions/spacedock.ts as a node
-// module next to the harness scripts in tmp.
+// module under tmp at the real package layout (<tmp>/.pi/extensions/), so the
+// extension's repo-root resolution (two levels up from the module) matches the
+// registered-package shape pi actually loads.
 func copyExtension(t *testing.T, repoRoot, tmp string) {
 	t.Helper()
 	extensionSource, err := os.ReadFile(filepath.Join(repoRoot, ".pi", "extensions", "spacedock.ts"))
 	if err != nil {
 		t.Fatalf("read extension: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(tmp, "spacedock-extension.mjs"), extensionSource, 0o644); err != nil {
+	modulePath := filepath.Join(tmp, ".pi", "extensions", "spacedock-extension.mjs")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatalf("stage extension dir: %v", err)
+	}
+	if err := os.WriteFile(modulePath, extensionSource, 0o644); err != nil {
 		t.Fatalf("write harness module: %v", err)
 	}
 }

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -6,7 +6,7 @@ Shared first-officer semantics — the boot-resident core. The active runtime ad
 
 **Launcher invariant:** Resolve executable `SPACEDOCK_BIN`, else `$PATH`'s `spacedock`; use `${SPACEDOCK_BIN:-spacedock}` always. Binary-absent success after approved install performs its ONE launcher resolution at that point. Never drift to a bare `spacedock` mid-session.
 
-1. **Binary gate.** Check `[ "${APP_SANDBOX_CONTAINER_ID:-}" = "agent-safehouse" ]`; inside, never offer/run installation; say to run it outside the sandbox. `${SPACEDOCK_BIN:-spacedock} --version` line 1 must be `spacedock <version>`. These skills require binary minor 0.28.
+1. **Binary gate.** Check `[ "${APP_SANDBOX_CONTAINER_ID:-}" = "agent-safehouse" ]`; inside, never offer/run installation; say to run it outside the sandbox. `${SPACEDOCK_BIN:-spacedock} --version` line 1 must be `spacedock <version>`. These skills require binary minor 0.28. The same output carries the contract token: this contract is **contract level 3**, and the `--version` output must contain `contract 3`. A different level, or a missing token → ABORT with a diagnostic naming the skill's declared level and the binary's token; remedy: `spacedock doctor` and update the plugin.
    - **Binary absent:** retry bare `spacedock` once if `SPACEDOCK_BIN` is unusable. Read `references/fo-install.md` — it owns channel classification, the per-OS install commands, the sandbox arm, and the install-and-resume offer.
    - **Wrong version:** major.minor below/above/absent (bare `dev`) → ABORT; `${SPACEDOCK_BIN:-spacedock} doctor`.
 2. **Boot — local identify.** Invoke `«state.boot»()` once and retain its boot record.


### PR DESCRIPTION
A plain `pi` session currently receives the first-officer bootstrap because the injection is ungated, and a stale FO contract proceeds silently against a newer binary — the 2026-09-10 stale-skill incident's residual paths. This change makes the bootstrap single-owner: injected only when `spacedock pi` launches the session, resolvable from any cwd, and self-checked against the binary.

## What changed

- Extension-owned, gated bootstrap (`.pi/extensions/spacedock.ts`): the FO bootstrap injects only when `PI_SPACEDOCK_LAUNCH=1` is set and the session is not a pi-subagents child; the wording points at the `<available_skills>` listing with absolute per-skill locations (no `$spacedock:` syntax, no relative SKILL.md path); `resources_discover` skips skill paths the package manifest already declares, so each skill registers exactly once.
- Frontdoor stays argv-only and gains a ready-gate health check (`internal/cli/pi.go`): extension file present, first-officer skill discoverable, route-aware duplicate-registration warning (packages × routes) naming all roots and the first-match winner, dev-override double-extension warning (`repoRoot` set AND a spacedock package registered), and a `pi >= 0.83.0` floor parsed from the binary's `pi --version` — sub-floor launches are refused with an `@earendil-works` upgrade diagnostic (the stale `@mariozechner`-org signal).
- Contract-level version self-check in the FO shared core: a session whose declared contract level mismatches the binary's `contract N` token aborts at the binary gate with a diagnostic naming both versions.
- Doc diffs applied as written to `docs/site/contributing/adding-a-runtime.md`.

## Evidence

- `bun test ./.pi/extensions/spacedock.test.ts` 4/4, including a falsification spot-check (forcing the gate open flips the suite 2 fail/2 pass; revert restores 4 pass). Entity Go test set green: frontdoor argv shape, marker env on every launch shape incl. the dev-override arm, ready-gate extension/first-officer/floor (0.82.9 refuse; 0.83.0/0.85.1/1.0.0 pass; `dev`/garbage refuse), duplicate + double-extension warnings, doctor report.
- Live probes, re-run fresh at validation (foreign cwd, isolated home, deterministic probe-extension dumps): plain `pi` still receives the installed ungated injection (baseline leak reproduced) while the gated extension injects nothing without the marker; `<available_skills>` lists `first-officer` exactly once with an absolute location and `/skill:first-officer` user input expands; dev-override arm both polarities; a stale contract fixture aborts naming contract 2 vs contract 3 with the current core passing as control; a sub-floor launch (0.73.1) is refused at the ready gate with the upgrade remedy.
- `go test ./internal/cli/`: the two failures present are pre-existing on the base commit (codex manifest resolver; env-dependent markers test) and stay deferred risk with promote-to-material conditions.
- Surface: +783 net (+876/−93) across 8 files vs the declared +270/6 (tolerance ±60/±2) — the excess is the revise-cycle test matrix and contract comments; flagged and adjudicated at the validation gate, no undeclared semantic beyond AC-5a's own dev-override refusal.

---
[s98](/spacedock-dev/spacedock/blob/09f1d16269ab4b9294308d0070799cb93430b7f0/pi-contract-bootstrap-single-owner.md)
